### PR TITLE
feat(#44): 일반 회원 비밀번호 재설정 기능 추가

### DIFF
--- a/healthtartFront/src/App.vue
+++ b/healthtartFront/src/App.vue
@@ -26,6 +26,7 @@ import { jwtDecode } from 'jwt-decode';
   const isMyPage = ref(false);
   const isRankingPage = ref(false);
   const isAddInfoPage = ref(false);
+  const isResetPasswordPage = ref(false);
 
 const loginState = reactive({
   isLoggedIn: false,
@@ -70,7 +71,8 @@ watch(() => route?.path, (newPath) => {
     isMyPage.value = newPath === '/mypage';
     isGymPage.value = newPath === '/gym';
     isRankingPage.value = newPath === '/ranking';
-    isAddInfoPage.value = newPath == '/users/addinfo'
+    isAddInfoPage.value = newPath === '/users/addinfo';
+    isResetPasswordPage.value = newPath === '/users/password'; 
   },
   {
     immediate: true

--- a/healthtartFront/src/components/users/LoginForm.vue
+++ b/healthtartFront/src/components/users/LoginForm.vue
@@ -26,7 +26,7 @@
         <div class="finds">
           <div class="find-email">이메일 찾기</div>
           <div>|</div>
-          <div class="find-password">비밀번호 찾기</div>
+          <div class="find-password" @click="goToPasswordReset">비밀번호 재설정</div>
           <div>|</div>
           <div class="signup" @click="goToSignup">회원가입</div>
         </div>
@@ -120,6 +120,11 @@ const loginUser = async () => {
 const goToSignup = () => {
   router.push('/users/signup'); // /users/signup 경로로 이동
 }
+
+const goToPasswordReset = () => {
+  router.push('/users/password'); // /users/password 경로로 이동
+};
+
 
 const kakaoLogin = () => {
   window.location.href = 'http://localhost:8080/oauth2/authorization/kakao';

--- a/healthtartFront/src/components/users/ResetPasswordForm1.vue
+++ b/healthtartFront/src/components/users/ResetPasswordForm1.vue
@@ -1,0 +1,222 @@
+<template>
+  <div class="outer-container">
+    <div class="form-container">
+      <form @submit.prevent="next">
+        <div class="reset_pwd_email-container">
+          <div class="reset_pwd_email-form">
+            <div class="reset_pwd_left-email">
+              <div class="reset_pwd_label-error-container">
+                <label for="email">이메일 *</label>
+                <div v-if="emailTouched && emailError" class="reset_pwd_error-message">올바른 이메일 형식을 입력해주세요.</div>
+              </div>
+
+              <div class="reset_pwd_email-input-group">
+                <input class="reset_pwd_inputinfo" type="text" id="email" required v-model="email" @blur="checkEmail" placeholder="이메일 입력" />
+                <button type="button" @click="sendVerificationEmail" class="reset_pwd_auth" :disabled="emailError || !email || isEmailSent">
+                  인증
+                </button>
+              </div>
+
+              <div class="reset_pwd_verification-form">
+                <label for="verificationCode">인증번호 *</label>
+                <div class="reset_pwd_verification-input-group">
+                  <input class="reset_pwd_inputinfo" type="text" id="verificationCode" placeholder="5분내로 인증번호를 입력해주세요" v-model="verificationCode" :disabled="!isEmailSent" />
+                  <button type="button" @click="verifyCode" class="reset_pwd_auth" :disabled="!isEmailSent || isVerified">확인</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <button type="submit" class="reset_pwd_next-btn" :disabled="!isVerified" @click="next">다음</button>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import axios from 'axios';
+
+// 이메일과 인증번호 관련 상태값
+const email = ref('');
+const verificationCode = ref('');
+const isEmailSent = ref(false);
+const isVerified = ref(false);
+const emailError = ref(false);
+const emailTouched = ref(false);
+
+// 유효성 검사
+const validateEmail = (email) => {
+  const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailPattern.test(email);
+};
+
+// 이메일 입력 필드를 벗어났을 때 유효성 검사
+const checkEmail = () => {
+  emailTouched.value = true;
+  emailError.value = !validateEmail(email.value);
+};
+
+// 이메일 인증 요청
+const sendVerificationEmail = async () => {
+  if (!emailError.value && email.value) {
+    try {
+      const response = await axios.post('http://localhost:8080/users/verification-email/password', { email: email.value });
+
+      if (response.data.success) {
+        alert('인증번호를 전송하였습니다.');
+        isEmailSent.value = true;
+      } else {
+        alert('인증번호 전송에 실패했습니다.');
+      }
+    } catch (error) {
+      alert('인증번호 전송 중 오류가 발생했습니다.');
+    }
+  }
+};
+
+// 인증번호 확인
+const verifyCode = async () => {
+  if (verificationCode.value) {
+    try {
+      const response = await axios.post('http://localhost:8080/users/verification-email/confirmation', {
+        email: email.value,
+        code: verificationCode.value
+      });
+
+      if (response.data.success) {
+        alert('인증번호 확인이 완료되었습니다.');
+        isVerified.value = true;
+      } else {
+        alert('인증번호가 일치하지 않습니다.');
+      }
+    } catch (error) {
+      alert('인증번호 확인에 실패했습니다.');
+    }
+  }
+};
+
+const emit = defineEmits(['next-step', 'update-email']);
+
+// 다음 단계로 넘어가는 함수
+const next = () => {
+  emit('update-email', email.value);  // 부모에게 이메일 전송
+  emit('next-step');
+};
+</script>
+
+<style scoped>
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+
+* {
+  font-family: 'Inter', sans-serif;
+}
+
+.outer-container {
+  width: 100%;
+  height: calc(100vh - 65px);;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.form-container {
+  background-color: #f0f4f8;
+  padding: 20px;
+  width: 380px;
+  margin-left: 880px;
+  margin-top: auto;
+  margin-bottom: auto;
+  border-radius: 20px;
+  box-shadow: -20px 20px 20px rgba(0, 255, 255, 0.5);
+  position: relative;
+}
+
+.reset_pwd_email-form {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.reset_pwd_left-email {
+  display: flex;
+  flex-direction: column;
+}
+
+label {
+  font-size: 14px;
+  margin-bottom: 8px;
+  font-weight: bold;
+}
+
+.reset_pwd_inputinfo {
+  font-size: 14px;
+  width: 270px;
+  height: 40px;
+  border-radius: 12px;
+  border: none;
+  box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.15);
+  padding-left: 10px;
+}
+
+.reset_pwd_auth {
+  background-color: #01FDFE;
+  width: 60px;
+  height: 40px;
+  border: none;
+  border-radius: 10px;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+  font-weight: bold;
+}
+
+.reset_pwd_auth:hover {
+  background-color: #1DEBEC;
+  cursor: pointer;
+}
+
+.reset_pwd_next-btn {
+  background-color: #01FDFE;
+  width: 100%;
+  height: 45px;
+  border-radius: 20px;
+  border: none;
+  box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+  font-weight: bold;
+  margin-top: 20px;
+}
+
+.reset_pwd_next-btn:hover {
+  background-color: #1DEBEC;
+  cursor: pointer;
+}
+
+
+.reset_pwd_email-input-group, .reset_pwd_verification-input-group {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 15px;
+  width: 100%;
+}
+
+.reset_pwd_email-input-group input, .reset_pwd_verification-input-group input {
+  flex: 1;
+}
+
+.reset_pwd_label-error-container {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.reset_pwd_label-error-container label {
+  margin-right: 10px;
+  margin-bottom: 0;
+}
+
+.reset_pwd_error-message {
+  color: red;
+  font-size: 12px;
+}
+</style>

--- a/healthtartFront/src/components/users/ResetPasswordForm2.vue
+++ b/healthtartFront/src/components/users/ResetPasswordForm2.vue
@@ -1,0 +1,200 @@
+<template>
+    <div class="outer-container">
+      <div class="form-container">
+        <form @submit.prevent="next">
+          <div class="reset_pwd_email-container">
+            <div class="reset_pwd_email-form">
+              <div class="reset_pwd_left-email">
+                <div class="reset_pwd_label-error-container">
+                  <label for="userPassword1">비밀번호 *</label>
+                  <div v-if="passwordTouched && passwordError" class="reset_pwd_error-message">비밀번호가 일치하지 않습니다.</div>
+                </div>
+  
+                <div class="reset_pwd_email-input-group">
+                  <input class="reset_pwd_inputinfo" type="password" id="userPassword1" required v-model="userPassword1"
+                    placeholder="비밀번호 입력" />
+                </div>
+                
+                <div class="reset_pwd_verification-form">
+                  <label for="userPassword2">비밀번호 확인 *</label>
+                  <div class="reset_pwd_verification-input-group">
+                    <input class="reset_pwd_inputinfo" type="password" id="userPassword2"
+                      placeholder="비밀번호 확인" v-model="userPassword2" />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+  
+          <button type="submit" class="reset_pwd_next-btn" @click="checkPasswordMatch">다음</button>
+        </form>
+      </div>
+    </div>
+  </template>
+  
+  <script setup>
+    import { ref, watch } from 'vue';
+    import axios from 'axios';
+    import { useRouter } from 'vue-router';
+
+  const props = defineProps({
+  userEmail: {
+    type: String,
+    required: true
+  }})  // 부모로부터 이메일을 받음
+
+  const userEmail = ref(props.userEmail);
+  console.log(userEmail);
+  const userPassword1 = ref('');  // 첫 번째 비밀번호
+  const userPassword2 = ref('');  // 두 번째 비밀번호
+  const passwordError = ref(true);  // 비밀번호 일치 여부
+  const passwordTouched = ref(false); // 비밀번호 입력 여부
+  const router = useRouter();  // Vue Router 사용
+  
+  // 비밀번호 일치 여부 확인 함수
+  const checkPasswordMatch = async () => {
+    passwordTouched.value = true;
+    if (userPassword1.value !== userPassword2.value) {
+      passwordError.value = true;
+    } else {
+      passwordError.value = false;
+      console.log(userPassword1, userPassword2, passwordError.value); 
+      await sendPasswordReset();
+    }
+  };
+
+    // 비밀번호 재설정 POST 요청 함수
+  const sendPasswordReset = async () => {
+    try {
+        console.log(userEmail.value);
+        console.log(userPassword1.value);
+        const response = await axios.post('http://localhost:8080/users/password', {
+            userEmail: userEmail.value,  // 부모로부터 받은 이메일
+            userPassword: userPassword1.value
+        });
+
+        // 성공적으로 요청이 처리되면 알림 표시 및 리다이렉트
+        alert('비밀번호 재설정 완료!');
+        router.push('/');  // 메인 페이지로 이동
+    } catch (error) {
+    console.error('비밀번호 재설정 실패:', error);
+    alert('비밀번호 재설정 실패. 다시 시도해주세요.');
+    }
+};
+  
+  </script>
+  
+  <style scoped>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
+  
+  * {
+    font-family: 'Inter', sans-serif;
+  }
+  
+  .outer-container {
+    width: 100%;
+    height: calc(100vh - 65px);;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+  }
+  
+  .form-container {
+    background-color: #f0f4f8;
+    padding: 20px;
+    width: 380px;
+    margin-left: 880px;
+    margin-top: auto;
+    margin-bottom: auto;
+    border-radius: 20px;
+    box-shadow: -20px 20px 20px rgba(0, 255, 255, 0.5);
+    position: relative;
+  }
+  
+  .reset_pwd_email-form {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  
+  .reset_pwd_left-email {
+    display: flex;
+    flex-direction: column;
+  }
+  
+  label {
+    font-size: 14px;
+    margin-bottom: 8px;
+    font-weight: bold;
+  }
+  
+  .reset_pwd_inputinfo {
+    font-size: 14px;
+    width: 340px;
+    height: 40px;
+    border-radius: 12px;
+    border: none;
+    box-shadow: 2px 2px 10px rgba(0, 0, 0, 0.15);
+    padding-left: 10px;
+  }
+  
+  .reset_pwd_auth {
+    background-color: #01FDFE;
+    width: 60px;
+    height: 40px;
+    border: none;
+    border-radius: 10px;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+    font-weight: bold;
+  }
+  
+  .reset_pwd_auth:hover {
+    background-color: #1DEBEC;
+    cursor: pointer;
+  }
+  
+  .reset_pwd_next-btn {
+    background-color: #01FDFE;
+    width: 100%;
+    height: 45px;
+    border-radius: 20px;
+    border: none;
+    box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.2);
+    font-weight: bold;
+    margin-top: 20px;
+  }
+  
+  .reset_pwd_next-btn:hover {
+    background-color: #1DEBEC;
+    cursor: pointer;
+  }
+  
+  
+  .reset_pwd_email-input-group, .reset_pwd_verification-input-group {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    width: 100%;
+  }
+  
+  .reset_pwd_email-input-group input, .reset_pwd_verification-input-group input {
+    flex: 1;
+  }
+  
+  .reset_pwd_label-error-container {
+    display: flex;
+    align-items: center;
+    margin-bottom: 8px;
+  }
+  
+  .reset_pwd_label-error-container label {
+    margin-right: 10px;
+    margin-bottom: 0;
+  }
+  
+  .reset_pwd_error-message {
+    color: red;
+    font-size: 12px;
+  }
+  </style>

--- a/healthtartFront/src/components/users/SignupStep1.vue
+++ b/healthtartFront/src/components/users/SignupStep1.vue
@@ -169,10 +169,13 @@ const verifyCode = async () => {
           'Content-Type': 'application/json'
         }
       });
-
-      if (response.status === 200) {
+      
+      console.log(response.data);
+      if (response.data.success === true) {
         alert('인증번호 확인이 완료되었습니다.');
         isVerified.value = true;
+      }else{
+        alert('인증번호가 일치하지 않습니다.');
       }
     } catch (error) {
       alert('인증번호 확인에 실패했습니다.');

--- a/healthtartFront/src/router/users.js
+++ b/healthtartFront/src/router/users.js
@@ -2,12 +2,14 @@ import MyPage from "@/views/users/MyPage.vue";
 import MyPageEdit from "@/views/users/MyPageEdit.vue";
 import LoginPage from "@/views/users/LoginPage.vue";
 import AddInfoPage from "../views/users/AddInfoPage.vue";
+import ResetPasswordPage from "../views/users/ResetPasswordPage.vue";
 
 const UserRoutes = [
     { path: "/mypage", component: MyPage },
     { path: "/mypage/edit", component: MyPageEdit },
     { path: "/users/login", component: LoginPage },
-    { path: "/users/addinfo", component: AddInfoPage}
+    { path: "/users/addinfo", component: AddInfoPage},
+    { path: "/users/password", component: ResetPasswordPage},
 ];
 
 export default UserRoutes;

--- a/healthtartFront/src/views/users/ResetPasswordPage.vue
+++ b/healthtartFront/src/views/users/ResetPasswordPage.vue
@@ -1,0 +1,30 @@
+<template>
+    <LoginBackground/>
+    <ResetPasswordForm1 v-if="currentStep === 1" @next-step="goToStep2" @update-email="updateEmail" />
+    <ResetPasswordForm2 v-if="currentStep === 2" :userEmail="userEmail" />
+  </template>
+  
+  <script setup>
+  import { ref } from 'vue';
+  import LoginBackground from '../../components/users/LoginBackground.vue';
+  import ResetPasswordForm1 from '../../components/users/ResetPasswordForm1.vue';
+  import ResetPasswordForm2 from '../../components/users/ResetPasswordForm2.vue';
+  
+  // 현재 단계와 이메일 상태값
+  const currentStep = ref(1);
+  const userEmail = ref('');
+  
+  // 단계 전환
+  const goToStep2 = () => {
+    currentStep.value = 2;
+  };
+  
+  // 자식 컴포넌트에서 이메일을 업데이트
+  const updateEmail = (newEmail) => {
+    userEmail.value = newEmail;
+    console.log(userEmail.value);
+  };
+  </script>
+  
+<style scoped>
+</style>


### PR DESCRIPTION
## 🔘Part
- [ ] BE
- [x] FE

  <br/>

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요
비밀번호 재설정 기능을 추가했습니다. 우선 이메일 인증을 통해 아이디(이메일)를 가져오고
비밀번호를 입력하여 입력한 이메일에 해당하는 비밀번호로 재설정합니다.

  <br/>

## 이미지 첨부
- 이메일 인증 구간
![image](https://github.com/user-attachments/assets/cc9f793a-d26c-4eaa-a84f-b2365ba453cd)
- 비밀번호 재설정 구간
![image](https://github.com/user-attachments/assets/f3eb4528-55af-45d5-95e5-553b79b50f03)

<br/>

## 🔧 앞으로의 과제

- 다음 할 일을 적어주세요 (앞으로의 할 일을 작성해도 괜찮습니다)
클릭이 안되게 하는 등 예외처리를 했지만 추가적인 예외처리
비밀번호 재설정시 특수문자 금지하는 코드가 없어 예외처리

  <br/>

close #44 
